### PR TITLE
Don't wrap spec.loader in HookLoader if spec.loader is None

### DIFF
--- a/importhook/finder.py
+++ b/importhook/finder.py
@@ -29,7 +29,7 @@ def hook_finder(finder):
         def wrapper(fullname, path, target=None):
             logger.debug(f'{finder_name}.find_spec(fullname={fullname}, path={path}, target={target})')
             spec = find_spec(fullname, path, target=target)
-            if spec is not None:
+            if spec is not None and spec.loader is not None:
                 spec.loader = HookLoader(spec.loader)
             return spec
         return wrapper
@@ -39,7 +39,10 @@ def hook_finder(finder):
         def wrapper(fullname, path):
             logger.debug(f'{finder_name}.find_loader(fullname={fullname}, path={path})')
             loader = find_loader(fullname, path)
-            return HookLoader(loader)
+            if loader is None:
+                return None
+            else:
+                return HookLoader(loader)
         return wrapper
 
     # Override the functions we care about


### PR DESCRIPTION
c.f. issue #6: https://github.com/brettlangdon/importhook/issues/6 for more details/examples

Certain packages that are 'namespace packages' don't return a loader object when they're, well, loaded. However in that case `importhook` still wraps spec.loader with a `HookLoader(loader=None)`, which messes up Python/importlib's None checks so it tries to call spec.loader.load_module instead of skipping. 

I was able to reproduce this on python3.10 with the following code:
```
import importhook
import snowflake # Causes attributeerror
```

The snowflake-related packages i have are: 
```
snowflake-connector-python               2.9.0
snowflake-sqlalchemy                     1.4.6
```

I'm not too familiar with the internals of how modules are loaded by Python so it's possible there's a more elegant way around this, or something I'm missing. However this PR seems to solve the issue