### PR TITLE
Remove meaningless `@functools.wraps` in `on_import` function

### DIFF
--- a/importhook/__init__.py
+++ b/importhook/__init__.py
@@ -68,7 +68,6 @@ def on_import(module_name, func=None):
         importhook.on_import('httplib', on_httplib_import)
     """
     if func is None:
-        @functools.wraps(func)
         def decorator(func):
             registry[module_name] = func
             return func

--- a/importhook/__init__.py
+++ b/importhook/__init__.py
@@ -16,7 +16,6 @@ Python module for registering hooks to call when certain modules are imported.
     # Import the `socket` module
     import socket
 """
-import functools
 import importlib
 import sys
 import types


### PR DESCRIPTION
Hello👋, this PR removes the unnecessary `@functools.wraps(func)` decorator in the `on_import` function. The specific line is redundant for the following reasons:

- The variable`func` is None, and passing `None` to `functools.wraps` serves no practical purpose.

- The `decorator` function is not a wrapper for `func`.

I hope this PR helps improve the project.😄